### PR TITLE
Fix incorrect submap id returned in Edges type

### DIFF
--- a/src/main/java/team/chisel/ctm/client/texture/TextureEdges.java
+++ b/src/main/java/team/chisel/ctm/client/texture/TextureEdges.java
@@ -42,9 +42,6 @@ public class TextureEdges extends TextureCTM {
 		ConnectionDirection[] directions = DIRECTION_MAP[quadrant];
 		boolean connected1 = logic.connected(directions[0]);
 		boolean connected2 = logic.connected(directions[1]);
-		if (logic.connected(directions[2]) && ((connected1 && connected2) || (!connected1 && !connected2))) {
-			return 0;
-		}
 		if (connected1 && connected2) {
 			return 3;
 		}
@@ -53,6 +50,9 @@ public class TextureEdges extends TextureCTM {
 		}
 		if (connected2) {
 			return 2;
+		}
+		if (logic.connected(directions[2])) {
+			return 0;
 		}
 		return -1;
 	}


### PR DESCRIPTION
Reorder TexturesEdges.getSubmapId condition to check for full corners first, then sides and last disconnected edges.

To fix issue: https://github.com/PepperCode1/ConnectedTexturesMod-Fabric/issues/31

New result:
![2021-08-09_17 47 42](https://user-images.githubusercontent.com/1721365/128746845-d6bf38b5-0c6e-4b65-a374-c14aeb697226.png)
